### PR TITLE
Unpack bug fields dynamically

### DIFF
--- a/bugsy/bug.py
+++ b/bugsy/bug.py
@@ -5,7 +5,7 @@ from .errors import BugException
 VALID_STATUS = ["RESOLVED", "ASSIGNED", "NEW", "UNCONFIRMED"]
 VALID_RESOLUTION = ["FIXED", "INCOMPLETE", "INVALID", "WORKSFORME",
                     "DUPLICATE", "WONTFIX"]
-ARRAY_TYPES = ["alias", "blocks", "cc", "cc_detail", "depends_on",
+ARRAY_TYPES = ["blocks", "cc", "cc_detail", "depends_on",
                "flags", "groups", "keywords", "see_also"]
 
 
@@ -19,7 +19,7 @@ def unpack(src):
         result['cc'] = [item['email'] for item in result['cc_detail']]
         del result['cc_detail']
     for field in ARRAY_TYPES:
-        if field not in result:
+        if field not in result or not result[field]:
             result[field] = []
 
     return result

--- a/bugsy/bug.py
+++ b/bugsy/bug.py
@@ -37,9 +37,9 @@ class Bug(object):
 
             >>> bug = Bug(**myDict)
         """
-        object.__setattr__(self, '_bugsy', bugsy)
-        object.__setattr__(self, '_bug', unpack(dict(**kwargs)))
-        object.__setattr__(self, '_copy', unpack(dict(**kwargs)))
+        self._bugsy = bugsy
+        self._bug = dict(**kwargs)
+        self._copy = dict(**kwargs)
         self._bug['op_sys'] = kwargs.get('op_sys', 'All')
         self._bug['product'] = kwargs.get('product', 'core')
         self._bug['component'] = kwargs.get('component', 'general')

--- a/bugsy/bug.py
+++ b/bugsy/bug.py
@@ -154,24 +154,19 @@ class Bug(object):
         changed = {}
         for key in self._bug:
             if key not in ARRAY_TYPES:
-                if key in self._copy and self._bug[key] != self._copy[key]:
+                if key not in self._copy or self._bug[key] != self._copy[key]:
                     changed[key] = self._bug[key]
             else:
-                additions = []
-                for item in self._bug[key]:
-                    if key not in self._copy or not self._copy[key] or item not in self._copy[key]:
-                        additions.append(item)
-                subtractions = []
-                if key in self._copy:
-                    for item in self._copy[key]:
-                        if item not in self._bug[key]:
-                            subtractions.append(item)
-                if len(additions) or len(subtractions):
+                values_now = set(self._bug.get(key, []))
+                values_orig = set(self._copy.get(key, []))
+                additions = list(values_now - values_orig)
+                subtractions = list(values_orig - values_now)
+                if additions or subtractions:
                     changed[key] = {}
                     if len(additions):
-                        changed[key]['added'] = additions
+                        changed[key]['add'] = additions
                     if len(subtractions):
-                        changed[key]['removed'] = subtractions
+                        changed[key]['remove'] = subtractions
         return changed
 
 

--- a/bugsy/bug.py
+++ b/bugsy/bug.py
@@ -264,8 +264,7 @@ class Bug(object):
             >>> bug.keywords
             [u"ateam-marionette-runner", u"regression"]
         """
-        keywords = [keyword for keyword in self._bug['keywords']]
-        return keywords
+        return self._bug['keywords']
 
     @keywords.setter
     def keywords(self, value):
@@ -298,8 +297,7 @@ class Bug(object):
             >>> bug.depends_on
             [123456, 678901]
         """
-        depends_on = [dep for dep in self._bug['depends_on']]
-        return depends_on
+        return self._bug['depends_on']
 
     @depends_on.setter
     def depends_on(self, value):
@@ -332,8 +330,7 @@ class Bug(object):
             >>> bug.blocks
             [123456, 678901]
         """
-        depends_on = [dep for dep in self._bug['blocks']]
-        return depends_on
+        return self._bug['blocks']
 
     @blocks.setter
     def blocks(self, value):

--- a/bugsy/bug.py
+++ b/bugsy/bug.py
@@ -96,6 +96,7 @@ class Bug(object):
         if 'id' in self._bug:
             result = self._bugsy.request('bug/%s' % self._bug['id'])
             self._bug = dict(**result['bugs'][0])
+            self._copy = dict(**result['bugs'][0])
         else:
             raise BugException("Unable to update bug that isn't in Bugzilla")
 

--- a/bugsy/bug.py
+++ b/bugsy/bug.py
@@ -18,6 +18,9 @@ def unpack(src):
     if 'cc_detail' in result:
         result['cc'] = [item['email'] for item in result['cc_detail']]
         del result['cc_detail']
+    for field in ARRAY_TYPES:
+        if field not in result:
+            result[field] = []
 
     return result
 
@@ -45,10 +48,7 @@ class Bug(object):
 
     def __getattr__(self, attr):
         if attr not in self._bug:
-            if attr in ARRAY_TYPES:
-                return []
-            else:
-                return None
+            return None
 
         return self._bug[attr]
 

--- a/bugsy/bug.py
+++ b/bugsy/bug.py
@@ -58,7 +58,7 @@ class Bug(object):
         elif attr == '_bugsy':
             object.__setattr__(self, attr, value)
         elif attr == 'status':
-            if self._bug.get('id', None):
+            if self.id:
                 if value in VALID_STATUS:
                     self._bug['status'] = value
                 else:

--- a/bugsy/bug.py
+++ b/bugsy/bug.py
@@ -2,9 +2,9 @@ import copy
 import datetime
 from .errors import BugException
 
-VALID_STATUS = ["RESOLVED", "ASSIGNED", "NEW", "UNCONFIRMED"]
-VALID_RESOLUTION = ["FIXED", "INCOMPLETE", "INVALID", "WORKSFORME",
-                    "DUPLICATE", "WONTFIX"]
+VALID_STATUS = ["ASSIGNED", "NEW", "RESOLVED", "UNCONFIRMED", "VERIFIED"]
+VALID_RESOLUTION = ["DUPLICATE", "FIXED", "INACTIVE", "INCOMPLETE",
+                    "INVALID", "MOVED", "WONTFIX", "WORKSFORME"]
 ARRAY_TYPES = ["blocks", "cc", "cc_detail", "depends_on",
                "flags", "groups", "keywords", "see_also"]
 

--- a/bugsy/bug.py
+++ b/bugsy/bug.py
@@ -74,7 +74,7 @@ class Bug(object):
         elif attr in ARRAY_TYPES and not isinstance(value, list):
             raise BugException("Cannot set value to non-list type")
         else:
-            self._bug[attr] = value
+            self._bug[attr] = copy.copy(value)
 
     def to_dict(self):
         """

--- a/bugsy/bugsy.py
+++ b/bugsy/bugsy.py
@@ -157,7 +157,7 @@ class Bugsy(object):
         if not bug.id:
             result = self.request('bug', 'POST', json=bug.to_dict())
             if 'error' not in result:
-                bug._bug['id'] = result['id']
+                bug.id = result['id']
                 bug._bugsy = self
                 try:
                     bug._bug.pop('comment')
@@ -169,7 +169,7 @@ class Bugsy(object):
                 raise BugsyException(result['message'])
         else:
             result = self.request('bug/%s' % bug.id, 'PUT',
-                                  json=bug.to_dict())
+                                  json=bug.diff())
             updated_bug = self.get(bug.id)
             return updated_bug
 

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -172,7 +172,7 @@ def test_we_throw_an_error_for_invalid_status_types():
     bug = Bug(**example_return['bugs'][0])
     try:
         bug.status = "foo"
-        assert 1 == 0, "Should have thrown an error about invalid type"
+        assert False, "Should have thrown an error about invalid type"
     except BugException as e:
         assert str(e) == "Message: Invalid status type was used Code: None"
 
@@ -189,7 +189,7 @@ def test_we_cant_set_the_resolution_when_not_valid():
     bug = Bug(**example_return['bugs'][0])
     try:
         bug.resolution = 'FOO'
-        assert 1==0, "Should thrown an error"
+        assert False, "Should thrown an error"
     except BugException as e:
         assert str(e) == "Message: Invalid resolution type was used Code: None"
 

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -20,7 +20,7 @@ status_b2g18': u'---', u'cf_status_b2g_1_4': u'---', u'url': u'', u'creator_deta
 ffin@mozilla.com', u'real_name': u'Jonathan Griffin (:jgriffin)'}, u'whiteboard': u'', u'cf_status_b2g_2_0': u'---', u'cc_detail': [{u'id': 30066, u'em\
 ail': u'coop@mozilla.com', u'name': u'coop@mozilla.com', u'real_name': u'Chris Cooper [:coop]'}, {u'id': 397261, u'email': u'dburns@mozilla.com', u'nam\
 e': u'dburns@mozilla.com', u'real_name': u'David Burns :automatedtester'}, {u'id': 438921, u'email': u'jlund@mozilla.com', u'name': u'jlund@mozilla.com', u'real_name': u'Jordan Lund (:jlund)'}, {u'id': 418814, u'email': u'mdas@mozilla.com', u'name': u'mdas@mozilla.com', u'real_name': u'Malini Das [:md\
-as]'}], u'alias': None, u'cf_tracking_b2g_v1_2': u'---', u'cf_tracking_b2g_v1_3': u'---', u'flags': [], u'assigned_to': u'jgriffin@mozilla.com', u'cf_s\
+as]'}], u'alias': [], u'cf_tracking_b2g_v1_2': u'---', u'cf_tracking_b2g_v1_3': u'---', u'flags': [], u'assigned_to': u'jgriffin@mozilla.com', u'cf_s\
 tatus_firefox_esr24': u'---', u'resolution': u'FIXED', u'last_change_time': u'2014-05-30T21:20:17Z', u'cc': [u'coop@mozilla.com', u'dburns@mozilla.com'
 , u'jlund@mozilla.com', u'mdas@mozilla.com'], u'cf_blocking_fennec': u'---'}]}
 

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -76,11 +76,11 @@ def test_we_cant_set_status_unless_there_is_a_bug_id():
 
 def test_we_can_get_OS_set_from_default():
     bug = Bug()
-    assert bug.OS == "All"
+    assert bug.op_sys == "All"
 
 def test_we_can_get_OS_we_set():
     bug = Bug(op_sys="Linux")
-    assert bug.OS == "Linux"
+    assert bug.op_sys == "Linux"
 
 def test_we_can_get_Product_set_from_default():
     bug = Bug()

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -91,108 +91,36 @@ def test_we_can_get_the_keywords():
     keywords = bug.keywords
     assert ['regression'] == keywords
 
-@responses.activate
 def test_we_can_add_single_keyword():
-    bug = None
-    bugzilla = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, 'https://bugzilla.mozilla.org/rest/login',
-                          body='{"token": "foobar"}', status=200,
-                          content_type='application/json', match_querystring=True)
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(example_return), status=200,
-                      content_type='application/json', match_querystring=True)
-        bugzilla = Bugsy("foo", "bar")
-        bug = bugzilla.get(1017315)
-    import copy
-    bug_dict = copy.deepcopy(example_return)
-    bug_dict['bugs'][0]['keywords'].append("ateam-marionette-server")
+    bug = Bug(**example_return['bugs'][0])
+    bug.keywords.append('ateam-marionette-server')
+    output = bug.diff()
+    assert isinstance(output, dict)
+    assert output == {'keywords': {
+        'added': ['ateam-marionette-server']
+    }}
+    assert ['regression', 'ateam-marionette-server'] == bug.keywords
 
-    updated_bug = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.PUT, 'https://bugzilla.mozilla.org/rest/bug/1017315',
-                    body=json.dumps(bug_dict), status=200,
-                    content_type='application/json', match_querystring=True)
-
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(bug_dict), status=200,
-                      content_type='application/json', match_querystring=True)
-
-        bug.keywords.append("ateam-marionette-server")
-        updated_bug = bugzilla.put(bug)
-
-    keywords = updated_bug.keywords
-    assert isinstance(keywords, list)
-    assert [u"regression", u"ateam-marionette-server"] == keywords
-
-@responses.activate
 def test_we_can_add_multiple_keywords_to_list():
-    bug = None
-    bugzilla = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, 'https://bugzilla.mozilla.org/rest/login',
-                          body='{"token": "foobar"}', status=200,
-                          content_type='application/json', match_querystring=True)
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(example_return), status=200,
-                      content_type='application/json', match_querystring=True)
-        bugzilla = Bugsy("foo", "bar")
-        bug = bugzilla.get(1017315)
-    import copy
-    bug_dict = copy.deepcopy(example_return)
-    bug_dict['bugs'][0]['keywords'].append("intermittent")
-    bug_dict['bugs'][0]['keywords'].append("ateam-marionette-server")
+    bug = Bug(**example_return['bugs'][0])
+    bug.keywords.extend(['intermittent', 'ateam-marionette-server'])
+    output = bug.diff()
+    assert isinstance(output, dict)
+    assert output == {'keywords': {
+        'added': ['intermittent', 'ateam-marionette-server']
+    }}
+    keywords = bug.keywords
+    assert sorted(['regression', 'intermittent', 'ateam-marionette-server']) == sorted(keywords)
 
-    updated_bug = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.PUT, 'https://bugzilla.mozilla.org/rest/bug/1017315',
-                    body=json.dumps(bug_dict), status=200,
-                    content_type='application/json', match_querystring=True)
-
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(bug_dict), status=200,
-                      content_type='application/json', match_querystring=True)
-
-        bug.keywords.extend(["intermittent", "ateam-marionette-server"])
-        updated_bug = bugzilla.put(bug)
-
-    keywords = updated_bug.keywords
-    assert isinstance(keywords, list)
-    assert ["regression", "intermittent", "ateam-marionette-server"] == keywords
-
-@responses.activate
 def test_we_can_add_remove_a_keyword_list():
-    bug = None
-    bugzilla = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, 'https://bugzilla.mozilla.org/rest/login',
-                          body='{"token": "foobar"}', status=200,
-                          content_type='application/json', match_querystring=True)
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(example_return), status=200,
-                      content_type='application/json', match_querystring=True)
-
-        bugzilla = Bugsy("foo", "bar")
-        bug = bugzilla.get(1017315)
-    import copy
-    bug_dict = copy.deepcopy(example_return)
-    bug_dict['bugs'][0]['keywords'].remove("regression")
-
-    updated_bug = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.PUT, 'https://bugzilla.mozilla.org/rest/bug/1017315',
-                    body=json.dumps(bug_dict), status=200,
-                    content_type='application/json', match_querystring=True)
-
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(bug_dict), status=200,
-                      content_type='application/json', match_querystring=True)
-
-        bug.keyword = ["regression-"]
-        updated_bug = bugzilla.put(bug)
-
-    keywords = updated_bug.keywords
-    assert isinstance(keywords, list)
+    bug = Bug(**example_return['bugs'][0])
+    bug.keywords.remove('regression')
+    output = bug.diff()
+    assert isinstance(output, dict)
+    assert output == {'keywords': {
+        'removed': ['regression']
+    }}
+    keywords = bug.keywords
     assert [] == keywords
 
 def test_we_can_get_Product_we_set():
@@ -206,156 +134,39 @@ def test_we_can_get_get_cc_list():
     assert sorted([u"coop@mozilla.com", u"dburns@mozilla.com",
             u"jlund@mozilla.com", u"mdas@mozilla.com"]) == sorted(cced)
 
-@responses.activate
 def test_we_can_add_single_email_to_cc_list():
-    bug = None
-    bugzilla = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, 'https://bugzilla.mozilla.org/rest/login',
-                          body='{"token": "foobar"}', status=200,
-                          content_type='application/json', match_querystring=True)
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(example_return), status=200,
-                      content_type='application/json', match_querystring=True)
-        bugzilla = Bugsy("foo", "bar")
-        bug = bugzilla.get(1017315)
-    import copy
-    bug_dict = copy.deepcopy(example_return)
-    bug_dict['bugs'][0]['cc_detail'].append({u'id': 438921, u'email': u'automatedtester@mozilla.com',
-                                u'name': u'automatedtester@mozilla.com', u'real_name': u'AutomatedTester'})
+    bug = Bug(**example_return['bugs'][0])
+    bug.cc.append('foo@bar.com')
+    output = bug.diff()
+    assert isinstance(output, dict)
+    assert output == {'cc': {'added': ['foo@bar.com']}}
 
-    updated_bug = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.PUT, 'https://bugzilla.mozilla.org/rest/bug/1017315',
-                    body=json.dumps(bug_dict), status=200,
-                    content_type='application/json', match_querystring=True)
-
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(bug_dict), status=200,
-                      content_type='application/json', match_querystring=True)
-
-        bug.cc.append("automatedtester@mozilla.com")
-        updated_bug = bugzilla.put(bug)
-
-    cced = updated_bug.cc
-    assert isinstance(cced, list)
-    assert sorted([u"coop@mozilla.com", u"dburns@mozilla.com",
-            u"jlund@mozilla.com", u"mdas@mozilla.com",
-            u"automatedtester@mozilla.com"]) == sorted(cced)
-
-@responses.activate
 def test_we_can_add_multiple_emails_to_cc_list():
-    bug = None
-    bugzilla = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, 'https://bugzilla.mozilla.org/rest/login',
-                          body='{"token": "foobar"}', status=200,
-                          content_type='application/json', match_querystring=True)
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(example_return), status=200,
-                      content_type='application/json', match_querystring=True)
-        bugzilla = Bugsy("foo", "bar")
-        bug = bugzilla.get(1017315)
-    import copy
-    bug_dict = copy.deepcopy(example_return)
-    bug_dict['bugs'][0]['cc_detail'].append({u'id': 438921, u'email': u'automatedtester@mozilla.com',
-                                u'name': u'automatedtester@mozilla.com', u'real_name': u'AutomatedTester'})
-    bug_dict['bugs'][0]['cc_detail'].append({u'id': 438922, u'email': u'foobar@mozilla.com',
-                                u'name': u'foobar@mozilla.com', u'real_name': u'Foobar'})
+    bug = Bug(**example_return['bugs'][0])
+    bug.cc.extend(['automatedtester@mozilla.com', 'foobar@mozilla.com'])
+    output = bug.diff()
+    assert isinstance(output, dict)
+    assert output == {'cc': {
+        'added': ['automatedtester@mozilla.com', 'foobar@mozilla.com']
+    }}
 
-    updated_bug = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.PUT, 'https://bugzilla.mozilla.org/rest/bug/1017315',
-                    body=json.dumps(bug_dict), status=200,
-                    content_type='application/json', match_querystring=True)
-
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(bug_dict), status=200,
-                      content_type='application/json', match_querystring=True)
-
-        bug.cc = ["automatedtester@mozilla.com", "foobar@mozilla.com"]
-        updated_bug = bugzilla.put(bug)
-
-    cced = updated_bug.cc
-    assert isinstance(cced, list)
-    assert sorted([u"coop@mozilla.com", u"dburns@mozilla.com",
-            u"jlund@mozilla.com", u"mdas@mozilla.com",
-            u"automatedtester@mozilla.com", u"foobar@mozilla.com"]) == sorted(cced)
-
-@responses.activate
 def test_we_can_add_remove_an_email_to_cc_list():
-    bug = None
-    bugzilla = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, 'https://bugzilla.mozilla.org/rest/login',
-                          body='{"token": "foobar"}', status=200,
-                          content_type='application/json', match_querystring=True)
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(example_return), status=200,
-                      content_type='application/json', match_querystring=True)
+    bug = Bug(**example_return['bugs'][0])
+    bug.cc.append('automatedtester@mozilla.com')
+    bug.cc.remove('dburns@mozilla.com')
+    output = bug.diff()
+    assert isinstance(output, dict)
+    assert output == {'cc': {
+        'added': ['automatedtester@mozilla.com'],
+        'removed': ['dburns@mozilla.com']
+    }}
 
-        bugzilla = Bugsy("foo", "bar")
-        bug = bugzilla.get(1017315)
-    import copy
-    bug_dict = copy.deepcopy(example_return)
-    bug_dict['bugs'][0]['cc_detail'].remove([person for person in bug_dict['bugs'][0]['cc_detail'] if person['id'] == 397261][0])
-    bug_dict['bugs'][0]['cc_detail'].append({u'id': 438921, u'email': u'automatedtester@mozilla.com',
-                                u'name': u'automatedtester@mozilla.com', u'real_name': u'AutomatedTester'})
-
-    updated_bug = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.PUT, 'https://bugzilla.mozilla.org/rest/bug/1017315',
-                    body=json.dumps(bug_dict), status=200,
-                    content_type='application/json', match_querystring=True)
-
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(bug_dict), status=200,
-                      content_type='application/json', match_querystring=True)
-
-        bug.cc.append("automatedtester@mozilla.com")
-        bug.cc.remove("dburns@mozilla.com")
-        updated_bug = bugzilla.put(bug)
-
-    cced = updated_bug.cc
-    assert isinstance(cced, list)
-    assert sorted([u"coop@mozilla.com", u"jlund@mozilla.com",
-            u"mdas@mozilla.com", u"automatedtester@mozilla.com"]) == sorted(cced)
-
-@responses.activate
 def test_we_can_remove_an_email_to_cc_list():
-    bug = None
-    bugzilla = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, 'https://bugzilla.mozilla.org/rest/login',
-                          body='{"token": "foobar"}', status=200,
-                          content_type='application/json', match_querystring=True)
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(example_return), status=200,
-                      content_type='application/json', match_querystring=True)
-
-        bugzilla = Bugsy("foo", "bar")
-        bug = bugzilla.get(1017315)
-    import copy
-    bug_dict = copy.deepcopy(example_return)
-    bug_dict['bugs'][0]['cc_detail'].remove([person for person in bug_dict['bugs'][0]['cc_detail'] if person['id'] == 397261][0])
-    bug_dict['bugs'][0]['cc_detail'].remove([person for person in bug_dict['bugs'][0]['cc_detail'] if person['id'] == 418814][0])
-
-    updated_bug = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.PUT, 'https://bugzilla.mozilla.org/rest/bug/1017315',
-                    body=json.dumps(bug_dict), status=200,
-                    content_type='application/json', match_querystring=True)
-
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(bug_dict), status=200,
-                      content_type='application/json', match_querystring=True)
-
-        bug.cc = ["automatedtester@mozilla.com", "dburns@mozilla.com-"]
-        updated_bug = bugzilla.put(bug)
-
-    cced = updated_bug.cc
-    assert isinstance(cced, list)
-    assert sorted([u"coop@mozilla.com", u"jlund@mozilla.com"]) == sorted(cced)
+    bug = Bug(**example_return['bugs'][0])
+    bug.cc.remove('dburns@mozilla.com')
+    output = bug.diff()
+    assert isinstance(output, dict)
+    assert output == {'cc': {'removed': ['dburns@mozilla.com']}}
 
 def test_we_throw_an_error_for_invalid_status_types():
     bug = Bug(**example_return['bugs'][0])
@@ -400,40 +211,17 @@ def test_we_can_get_depends_on_list():
     assert isinstance(depends_on, list)
     assert depends_on == [123456]
 
-@responses.activate
 def test_we_can_add_and_remove_depends_on():
-    bug = None
-    bugzilla = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, 'https://bugzilla.mozilla.org/rest/login',
-                          body='{"token": "foobar"}', status=200,
-                          content_type='application/json', match_querystring=True)
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(example_return), status=200,
-                      content_type='application/json', match_querystring=True)
-
-        bugzilla = Bugsy("foo", "bar")
-        bug = bugzilla.get(1017315)
-    import copy
-    bug_dict = copy.deepcopy(example_return)
-    bug_dict['bugs'][0]['depends_on'].remove(123456)
-    bug_dict['bugs'][0]['depends_on'].append(145123)
-
-    updated_bug = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.PUT, 'https://bugzilla.mozilla.org/rest/bug/1017315',
-                    body=json.dumps(bug_dict), status=200,
-                    content_type='application/json', match_querystring=True)
-
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(bug_dict), status=200,
-                      content_type='application/json', match_querystring=True)
-
-        bug.depends_on.remove(123456)
-        bug.depends_on.append(145123)
-        updated_bug = bugzilla.put(bug)
-
-    deps = updated_bug.depends_on
+    bug = Bug(**example_return['bugs'][0])
+    bug.depends_on.remove(123456)
+    bug.depends_on.append(145123)
+    output = bug.diff()
+    assert isinstance(output, dict)
+    assert output == {'depends_on': {
+        'added': [145123],
+        'removed': [123456]
+    }}
+    deps = bug.depends_on
     assert isinstance(deps, list)
     assert [145123] == deps
 
@@ -443,39 +231,17 @@ def test_we_can_get_blocks_list():
     assert isinstance(blocks, list)
     assert blocks == [654321]
 
-@responses.activate
 def test_we_can_add_and_remove_blocks():
-    bug = None
-    bugzilla = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.GET, 'https://bugzilla.mozilla.org/rest/login',
-                          body='{"token": "foobar"}', status=200,
-                          content_type='application/json', match_querystring=True)
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(example_return), status=200,
-                      content_type='application/json', match_querystring=True)
-
-        bugzilla = Bugsy("foo", "bar")
-        bug = bugzilla.get(1017315)
-    import copy
-    bug_dict = copy.deepcopy(example_return)
-    bug_dict['bugs'][0]['blocks'].remove(654321)
-    bug_dict['bugs'][0]['blocks'].append(145123)
-
-    updated_bug = None
-    with responses.RequestsMock() as rsps:
-        rsps.add(responses.PUT, 'https://bugzilla.mozilla.org/rest/bug/1017315',
-                    body=json.dumps(bug_dict), status=200,
-                    content_type='application/json', match_querystring=True)
-
-        rsps.add(responses.GET, rest_url('bug', 1017315),
-                      body=json.dumps(bug_dict), status=200,
-                      content_type='application/json', match_querystring=True)
-
-        bug.blocks = ["654321-", "145123"]
-        updated_bug = bugzilla.put(bug)
-
-    deps = updated_bug.blocks
+    bug = Bug(**example_return['bugs'][0])
+    bug.blocks.remove(654321)
+    bug.blocks.append(145123)
+    output = bug.diff()
+    assert isinstance(output, dict)
+    assert output == {'blocks': {
+        'added': [145123],
+        'removed': [654321]
+    }}
+    deps = bug.blocks
     assert isinstance(deps, list)
     assert [145123] == deps
 

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -86,7 +86,7 @@ def test_we_can_get_Product_set_from_default():
     bug = Bug()
     assert bug.product == "core"
 
-def test_we_can_get_get_the_keywords():
+def test_we_can_get_the_keywords():
     bug = Bug(**example_return['bugs'][0])
     keywords = bug.keywords
     assert [u'regression'] == keywords

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -203,8 +203,8 @@ def test_we_can_get_get_cc_list():
     bug = Bug(**example_return['bugs'][0])
     cced = bug.cc
     assert isinstance(cced, list)
-    assert [u"coop@mozilla.com", u"dburns@mozilla.com",
-            u"jlund@mozilla.com", u"mdas@mozilla.com"] == cced
+    assert sorted([u"coop@mozilla.com", u"dburns@mozilla.com",
+            u"jlund@mozilla.com", u"mdas@mozilla.com"]) == sorted(cced)
 
 @responses.activate
 def test_we_can_add_single_email_to_cc_list():
@@ -239,9 +239,9 @@ def test_we_can_add_single_email_to_cc_list():
 
     cced = updated_bug.cc
     assert isinstance(cced, list)
-    assert [u"coop@mozilla.com", u"dburns@mozilla.com",
+    assert sorted([u"coop@mozilla.com", u"dburns@mozilla.com",
             u"jlund@mozilla.com", u"mdas@mozilla.com",
-            u"automatedtester@mozilla.com"] == cced
+            u"automatedtester@mozilla.com"]) == sorted(cced)
 
 @responses.activate
 def test_we_can_add_multiple_emails_to_cc_list():
@@ -278,9 +278,9 @@ def test_we_can_add_multiple_emails_to_cc_list():
 
     cced = updated_bug.cc
     assert isinstance(cced, list)
-    assert [u"coop@mozilla.com", u"dburns@mozilla.com",
+    assert sorted([u"coop@mozilla.com", u"dburns@mozilla.com",
             u"jlund@mozilla.com", u"mdas@mozilla.com",
-            u"automatedtester@mozilla.com", u"foobar@mozilla.com"] == cced
+            u"automatedtester@mozilla.com", u"foobar@mozilla.com"]) == sorted(cced)
 
 @responses.activate
 def test_we_can_add_remove_an_email_to_cc_list():
@@ -318,8 +318,8 @@ def test_we_can_add_remove_an_email_to_cc_list():
 
     cced = updated_bug.cc
     assert isinstance(cced, list)
-    assert [u"coop@mozilla.com", u"jlund@mozilla.com",
-            u"mdas@mozilla.com", u"automatedtester@mozilla.com"] == cced
+    assert sorted([u"coop@mozilla.com", u"jlund@mozilla.com",
+            u"mdas@mozilla.com", u"automatedtester@mozilla.com"]) == sorted(cced)
 
 @responses.activate
 def test_we_can_remove_an_email_to_cc_list():
@@ -355,7 +355,7 @@ def test_we_can_remove_an_email_to_cc_list():
 
     cced = updated_bug.cc
     assert isinstance(cced, list)
-    assert [u"coop@mozilla.com", u"jlund@mozilla.com"] == cced
+    assert sorted([u"coop@mozilla.com", u"jlund@mozilla.com"]) == sorted(cced)
 
 def test_we_throw_an_error_for_invalid_status_types():
     bug = Bug(**example_return['bugs'][0])

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -61,11 +61,11 @@ comments_return = {
 
 def test_can_create_bug_and_set_summary_afterwards():
     bug = Bug()
-    assert bug.id == None, "Id has been set"
-    assert bug.summary == '', "Summary is not set to nothing on plain initialisation"
+    assert bug.id is None, "Id has been set"
+    assert bug.summary is None, "Summary is not set to nothing on plain initialisation"
     bug.summary = "Foo"
     assert bug.summary == 'Foo', "Summary is not being set"
-    assert bug.status == '', 'Status has been set'
+    assert bug.status is None, 'Status has been set'
 
 def test_we_cant_set_status_unless_there_is_a_bug_id():
     bug = Bug()

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -460,3 +460,10 @@ def test_we_can_remove_tags_to_bug_comments():
     comments[0].remove_tags("foo")
 
     assert len(responses.calls) == 4
+
+def test_adding_new_field_to_existing_bug():
+    # This can occur if a bug is retrieved using limited fields
+    bug = Bug({})
+    bug.alias = 'foobar'
+    diff = bug.diff()
+    assert diff['alias'] == 'foobar'

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -20,7 +20,7 @@ status_b2g18': u'---', u'cf_status_b2g_1_4': u'---', u'url': u'', u'creator_deta
 ffin@mozilla.com', u'real_name': u'Jonathan Griffin (:jgriffin)'}, u'whiteboard': u'', u'cf_status_b2g_2_0': u'---', u'cc_detail': [{u'id': 30066, u'em\
 ail': u'coop@mozilla.com', u'name': u'coop@mozilla.com', u'real_name': u'Chris Cooper [:coop]'}, {u'id': 397261, u'email': u'dburns@mozilla.com', u'nam\
 e': u'dburns@mozilla.com', u'real_name': u'David Burns :automatedtester'}, {u'id': 438921, u'email': u'jlund@mozilla.com', u'name': u'jlund@mozilla.com', u'real_name': u'Jordan Lund (:jlund)'}, {u'id': 418814, u'email': u'mdas@mozilla.com', u'name': u'mdas@mozilla.com', u'real_name': u'Malini Das [:md\
-as]'}], u'alias': [], u'cf_tracking_b2g_v1_2': u'---', u'cf_tracking_b2g_v1_3': u'---', u'flags': [], u'assigned_to': u'jgriffin@mozilla.com', u'cf_s\
+as]'}], u'alias': None, u'cf_tracking_b2g_v1_2': u'---', u'cf_tracking_b2g_v1_3': u'---', u'flags': [], u'assigned_to': u'jgriffin@mozilla.com', u'cf_s\
 tatus_firefox_esr24': u'---', u'resolution': u'FIXED', u'last_change_time': u'2014-05-30T21:20:17Z', u'cc': [u'coop@mozilla.com', u'dburns@mozilla.com'
 , u'jlund@mozilla.com', u'mdas@mozilla.com'], u'cf_blocking_fennec': u'---'}]}
 

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -252,15 +252,15 @@ def test_we_can_update_a_bug_from_bugzilla():
                       content_type='application/json', match_querystring=True)
     bugzilla = Bugsy()
     bug = bugzilla.get(1017315)
-    import copy
-    bug_dict = copy.deepcopy(example_return)
-    bug_dict['bugs'][0]['status'] = "REOPENED"
     responses.reset()
     responses.add(responses.GET, 'https://bugzilla.mozilla.org/rest/bug/1017315',
-                      body=json.dumps(bug_dict), status=200,
+                      body=json.dumps(example_return), status=200,
                       content_type='application/json')
-    bug.update()
-    assert bug.status == 'REOPENED'
+    clone = Bug(bugsy=bugzilla, **bug.to_dict())
+    clone.status = 'NEW'
+    clone.update()
+    assert clone.id == 1017315
+    assert clone.status == 'RESOLVED'
 
 def test_we_cant_update_unless_we_have_a_bug_id():
     bug = Bug()
@@ -278,19 +278,17 @@ def test_we_can_update_a_bug_with_login_token():
   responses.add(responses.GET, rest_url('bug', 1017315),
                     body=json.dumps(example_return), status=200,
                     content_type='application/json', match_querystring=True)
-  bugzilla = Bugsy("foo", "bar")
+  bugzilla = Bugsy()
   bug = bugzilla.get(1017315)
-  import copy
-  bug_dict = copy.deepcopy(example_return)
-  bug_dict['bugs'][0]['status'] = "REOPENED"
   responses.reset()
   responses.add(responses.GET, 'https://bugzilla.mozilla.org/rest/bug/1017315',
-                    body=json.dumps(bug_dict), status=200,
-                    content_type='application/json', match_querystring=True)
-  bug.update()
-  assert bug.id == 1017315
-  assert bug.status == 'REOPENED'
-  assert bug.summary == 'Schedule Mn tests on opt Linux builds on cedar'
+                body=json.dumps(example_return), status=200,
+                content_type='application/json')
+  clone = Bug(bugsy=bugzilla, **bug.to_dict())
+  clone.status = 'NEW'
+  clone.update()
+  assert clone.id == 1017315
+  assert clone.status == 'RESOLVED'
 
 @responses.activate
 def test_that_we_can_add_a_comment_to_a_bug_before_it_is_put():

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -19,7 +19,7 @@ _milestone': u'---', u'is_cc_accessible': True, u'cf_tracking_firefox_esr24': u'
 status_b2g18': u'---', u'cf_status_b2g_1_4': u'---', u'url': u'', u'creator_detail': {u'id': 347295, u'email': u'jgriffin@mozilla.com', u'name': u'jgri\
 ffin@mozilla.com', u'real_name': u'Jonathan Griffin (:jgriffin)'}, u'whiteboard': u'', u'cf_status_b2g_2_0': u'---', u'cc_detail': [{u'id': 30066, u'em\
 ail': u'coop@mozilla.com', u'name': u'coop@mozilla.com', u'real_name': u'Chris Cooper [:coop]'}, {u'id': 397261, u'email': u'dburns@mozilla.com', u'nam\
-e': u'dburns@mozilla.com', u'real_name': u'David Burns :automatedtester'}, {u'id': 438921, u'email': u'jlund@mozilla.com', u'name': u'jlund@mozilla.com ', u'real_name': u'Jordan Lund (:jlund)'}, {u'id': 418814, u'email': u'mdas@mozilla.com', u'name': u'mdas@mozilla.com', u'real_name': u'Malini Das [:md\
+e': u'dburns@mozilla.com', u'real_name': u'David Burns :automatedtester'}, {u'id': 438921, u'email': u'jlund@mozilla.com', u'name': u'jlund@mozilla.com', u'real_name': u'Jordan Lund (:jlund)'}, {u'id': 418814, u'email': u'mdas@mozilla.com', u'name': u'mdas@mozilla.com', u'real_name': u'Malini Das [:md\
 as]'}], u'alias': None, u'cf_tracking_b2g_v1_2': u'---', u'cf_tracking_b2g_v1_3': u'---', u'flags': [], u'assigned_to': u'jgriffin@mozilla.com', u'cf_s\
 tatus_firefox_esr24': u'---', u'resolution': u'FIXED', u'last_change_time': u'2014-05-30T21:20:17Z', u'cc': [u'coop@mozilla.com', u'dburns@mozilla.com'
 , u'jlund@mozilla.com', u'mdas@mozilla.com'], u'cf_blocking_fennec': u'---'}]}
@@ -222,7 +222,7 @@ def test_we_can_add_single_email_to_cc_list():
     import copy
     bug_dict = copy.deepcopy(example_return)
     bug_dict['bugs'][0]['cc_detail'].append({u'id': 438921, u'email': u'automatedtester@mozilla.com',
-                                u'name': u'automatedtester@mozilla.com ', u'real_name': u'AutomatedTester'})
+                                u'name': u'automatedtester@mozilla.com', u'real_name': u'AutomatedTester'})
 
     updated_bug = None
     with responses.RequestsMock() as rsps:
@@ -259,9 +259,9 @@ def test_we_can_add_multiple_emails_to_cc_list():
     import copy
     bug_dict = copy.deepcopy(example_return)
     bug_dict['bugs'][0]['cc_detail'].append({u'id': 438921, u'email': u'automatedtester@mozilla.com',
-                                u'name': u'automatedtester@mozilla.com ', u'real_name': u'AutomatedTester'})
+                                u'name': u'automatedtester@mozilla.com', u'real_name': u'AutomatedTester'})
     bug_dict['bugs'][0]['cc_detail'].append({u'id': 438922, u'email': u'foobar@mozilla.com',
-                                u'name': u'foobar@mozilla.com ', u'real_name': u'Foobar'})
+                                u'name': u'foobar@mozilla.com', u'real_name': u'Foobar'})
 
     updated_bug = None
     with responses.RequestsMock() as rsps:
@@ -300,7 +300,7 @@ def test_we_can_add_remove_an_email_to_cc_list():
     bug_dict = copy.deepcopy(example_return)
     bug_dict['bugs'][0]['cc_detail'].remove([person for person in bug_dict['bugs'][0]['cc_detail'] if person['id'] == 397261][0])
     bug_dict['bugs'][0]['cc_detail'].append({u'id': 438921, u'email': u'automatedtester@mozilla.com',
-                                u'name': u'automatedtester@mozilla.com ', u'real_name': u'AutomatedTester'})
+                                u'name': u'automatedtester@mozilla.com', u'real_name': u'AutomatedTester'})
 
     updated_bug = None
     with responses.RequestsMock() as rsps:

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -89,7 +89,7 @@ def test_we_can_get_Product_set_from_default():
 def test_we_can_get_the_keywords():
     bug = Bug(**example_return['bugs'][0])
     keywords = bug.keywords
-    assert [u'regression'] == keywords
+    assert ['regression'] == keywords
 
 @responses.activate
 def test_we_can_add_single_keyword():

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -131,8 +131,8 @@ def test_we_can_get_get_cc_list():
     bug = Bug(**example_return['bugs'][0])
     cced = bug.cc
     assert isinstance(cced, list)
-    assert sorted([u"coop@mozilla.com", u"dburns@mozilla.com",
-            u"jlund@mozilla.com", u"mdas@mozilla.com"]) == sorted(cced)
+    assert ['coop@mozilla.com', 'dburns@mozilla.com',
+            'jlund@mozilla.com', 'mdas@mozilla.com'] == cced
 
 def test_we_can_add_single_email_to_cc_list():
     bug = Bug(**example_return['bugs'][0])

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -118,7 +118,7 @@ def test_we_can_add_single_keyword():
                       body=json.dumps(bug_dict), status=200,
                       content_type='application/json', match_querystring=True)
 
-        bug.keywords = "ateam-marionette-server"
+        bug.keywords = ["ateam-marionette-server"]
         updated_bug = bugzilla.put(bug)
 
     keywords = updated_bug.keywords
@@ -234,7 +234,7 @@ def test_we_can_add_single_email_to_cc_list():
                       body=json.dumps(bug_dict), status=200,
                       content_type='application/json', match_querystring=True)
 
-        bug.cc = "automatedtester@mozilla.com"
+        bug.cc.append("automatedtester@mozilla.com")
         updated_bug = bugzilla.put(bug)
 
     cced = updated_bug.cc
@@ -312,7 +312,8 @@ def test_we_can_add_remove_an_email_to_cc_list():
                       body=json.dumps(bug_dict), status=200,
                       content_type='application/json', match_querystring=True)
 
-        bug.cc = ["automatedtester@mozilla.com", "dburns@mozilla.com-"]
+        bug.cc.append("automatedtester@mozilla.com")
+        bug.cc.remove("dburns@mozilla.com")
         updated_bug = bugzilla.put(bug)
 
     cced = updated_bug.cc
@@ -428,7 +429,8 @@ def test_we_can_add_and_remove_depends_on():
                       body=json.dumps(bug_dict), status=200,
                       content_type='application/json', match_querystring=True)
 
-        bug.depends_on = ["123456-", "145123"]
+        bug.depends_on.remove(123456)
+        bug.depends_on.append(145123)
         updated_bug = bugzilla.put(bug)
 
     deps = updated_bug.depends_on

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -118,7 +118,7 @@ def test_we_can_add_single_keyword():
                       body=json.dumps(bug_dict), status=200,
                       content_type='application/json', match_querystring=True)
 
-        bug.keywords = ["ateam-marionette-server"]
+        bug.keywords.append("ateam-marionette-server")
         updated_bug = bugzilla.put(bug)
 
     keywords = updated_bug.keywords
@@ -153,7 +153,7 @@ def test_we_can_add_multiple_keywords_to_list():
                       body=json.dumps(bug_dict), status=200,
                       content_type='application/json', match_querystring=True)
 
-        bug.keywords = ["intermittent", "ateam-marionette-server"]
+        bug.keywords.extend(["intermittent", "ateam-marionette-server"])
         updated_bug = bugzilla.put(bug)
 
     keywords = updated_bug.keywords

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -97,7 +97,7 @@ def test_we_can_add_single_keyword():
     output = bug.diff()
     assert isinstance(output, dict)
     assert output == {'keywords': {
-        'added': ['ateam-marionette-server']
+        'add': ['ateam-marionette-server']
     }}
     assert ['regression', 'ateam-marionette-server'] == bug.keywords
 
@@ -106,9 +106,7 @@ def test_we_can_add_multiple_keywords_to_list():
     bug.keywords.extend(['intermittent', 'ateam-marionette-server'])
     output = bug.diff()
     assert isinstance(output, dict)
-    assert output == {'keywords': {
-        'added': ['intermittent', 'ateam-marionette-server']
-    }}
+    assert sorted(output['keywords']['add']) == sorted(['intermittent', 'ateam-marionette-server'])
     keywords = bug.keywords
     assert sorted(['regression', 'intermittent', 'ateam-marionette-server']) == sorted(keywords)
 
@@ -118,7 +116,7 @@ def test_we_can_add_remove_a_keyword_list():
     output = bug.diff()
     assert isinstance(output, dict)
     assert output == {'keywords': {
-        'removed': ['regression']
+        'remove': ['regression']
     }}
     keywords = bug.keywords
     assert [] == keywords
@@ -139,16 +137,14 @@ def test_we_can_add_single_email_to_cc_list():
     bug.cc.append('foo@bar.com')
     output = bug.diff()
     assert isinstance(output, dict)
-    assert output == {'cc': {'added': ['foo@bar.com']}}
+    assert output == {'cc': {'add': ['foo@bar.com']}}
 
 def test_we_can_add_multiple_emails_to_cc_list():
     bug = Bug(**example_return['bugs'][0])
     bug.cc.extend(['automatedtester@mozilla.com', 'foobar@mozilla.com'])
     output = bug.diff()
     assert isinstance(output, dict)
-    assert output == {'cc': {
-        'added': ['automatedtester@mozilla.com', 'foobar@mozilla.com']
-    }}
+    assert sorted(output['cc']['add']) == sorted(['automatedtester@mozilla.com', 'foobar@mozilla.com'])
 
 def test_we_can_add_remove_an_email_to_cc_list():
     bug = Bug(**example_return['bugs'][0])
@@ -157,8 +153,8 @@ def test_we_can_add_remove_an_email_to_cc_list():
     output = bug.diff()
     assert isinstance(output, dict)
     assert output == {'cc': {
-        'added': ['automatedtester@mozilla.com'],
-        'removed': ['dburns@mozilla.com']
+        'add': ['automatedtester@mozilla.com'],
+        'remove': ['dburns@mozilla.com']
     }}
 
 def test_we_can_remove_an_email_to_cc_list():
@@ -166,7 +162,7 @@ def test_we_can_remove_an_email_to_cc_list():
     bug.cc.remove('dburns@mozilla.com')
     output = bug.diff()
     assert isinstance(output, dict)
-    assert output == {'cc': {'removed': ['dburns@mozilla.com']}}
+    assert output == {'cc': {'remove': ['dburns@mozilla.com']}}
 
 def test_we_throw_an_error_for_invalid_status_types():
     bug = Bug(**example_return['bugs'][0])
@@ -218,8 +214,8 @@ def test_we_can_add_and_remove_depends_on():
     output = bug.diff()
     assert isinstance(output, dict)
     assert output == {'depends_on': {
-        'added': [145123],
-        'removed': [123456]
+        'add': [145123],
+        'remove': [123456]
     }}
     deps = bug.depends_on
     assert isinstance(deps, list)
@@ -238,8 +234,8 @@ def test_we_can_add_and_remove_blocks():
     output = bug.diff()
     assert isinstance(output, dict)
     assert output == {'blocks': {
-        'added': [145123],
-        'removed': [654321]
+        'add': [145123],
+        'remove': [654321]
     }}
     deps = bug.blocks
     assert isinstance(deps, list)

--- a/tests/test_bugsy.py
+++ b/tests/test_bugsy.py
@@ -19,7 +19,7 @@ status_b2g18': u'---', u'cf_status_b2g_1_4': u'---', u'url': u'', u'creator_deta
 ffin@mozilla.com', u'real_name': u'Jonathan Griffin (:jgriffin)'}, u'whiteboard': u'', u'cf_status_b2g_2_0': u'---', u'cc_detail': [{u'id': 30066, u'em\
 ail': u'coop@mozilla.com', u'name': u'coop@mozilla.com', u'real_name': u'Chris Cooper [:coop]'}, {u'id': 397261, u'email': u'dburns@mozilla.com', u'nam\
 e': u'dburns@mozilla.com', u'real_name': u'David Burns :automatedtester'}, {u'id': 438921, u'email': u'jlund@mozilla.com', u'name': u'jlund@mozilla.com ', u'real_name': u'Jordan Lund (:jlund)'}, {u'id': 418814, u'email': u'mdas@mozilla.com', u'name': u'mdas@mozilla.com', u'real_name': u'Malini Das [:md\
-as]'}], u'alias': None, u'cf_tracking_b2g_v1_2': u'---', u'cf_tracking_b2g_v1_3': u'---', u'flags': [], u'assigned_to': u'jgriffin@mozilla.com', u'cf_s\
+as]'}], u'alias': [], u'cf_tracking_b2g_v1_2': u'---', u'cf_tracking_b2g_v1_3': u'---', u'flags': [], u'assigned_to': u'jgriffin@mozilla.com', u'cf_s\
 tatus_firefox_esr24': u'---', u'resolution': u'FIXED', u'last_change_time': u'2014-05-30T21:20:17Z', u'cc': [u'coop@mozilla.com', u'dburns@mozilla.com'
 , u'jlund@mozilla.com', u'mdas@mozilla.com'], u'cf_blocking_fennec': u'---'}]}
 

--- a/tests/test_bugsy.py
+++ b/tests/test_bugsy.py
@@ -19,7 +19,7 @@ status_b2g18': u'---', u'cf_status_b2g_1_4': u'---', u'url': u'', u'creator_deta
 ffin@mozilla.com', u'real_name': u'Jonathan Griffin (:jgriffin)'}, u'whiteboard': u'', u'cf_status_b2g_2_0': u'---', u'cc_detail': [{u'id': 30066, u'em\
 ail': u'coop@mozilla.com', u'name': u'coop@mozilla.com', u'real_name': u'Chris Cooper [:coop]'}, {u'id': 397261, u'email': u'dburns@mozilla.com', u'nam\
 e': u'dburns@mozilla.com', u'real_name': u'David Burns :automatedtester'}, {u'id': 438921, u'email': u'jlund@mozilla.com', u'name': u'jlund@mozilla.com ', u'real_name': u'Jordan Lund (:jlund)'}, {u'id': 418814, u'email': u'mdas@mozilla.com', u'name': u'mdas@mozilla.com', u'real_name': u'Malini Das [:md\
-as]'}], u'alias': [], u'cf_tracking_b2g_v1_2': u'---', u'cf_tracking_b2g_v1_3': u'---', u'flags': [], u'assigned_to': u'jgriffin@mozilla.com', u'cf_s\
+as]'}], u'alias': None, u'cf_tracking_b2g_v1_2': u'---', u'cf_tracking_b2g_v1_3': u'---', u'flags': [], u'assigned_to': u'jgriffin@mozilla.com', u'cf_s\
 tatus_firefox_esr24': u'---', u'resolution': u'FIXED', u'last_change_time': u'2014-05-30T21:20:17Z', u'cc': [u'coop@mozilla.com', u'dburns@mozilla.com'
 , u'jlund@mozilla.com', u'mdas@mozilla.com'], u'cf_blocking_fennec': u'---'}]}
 


### PR DESCRIPTION
This PR modified the Bug class to unpack available fields dynamically rather than defining explicit getters/setters for each field. This addresses issue #40.

The tests have been updated to verify this behavior. Furthermore, several tests were using ResponseMocks unnecessarily as the response body was set as the same object that was used in the request.